### PR TITLE
Output format fix

### DIFF
--- a/eztest/eztest.h
+++ b/eztest/eztest.h
@@ -1022,7 +1022,7 @@ void _assert_are_not_equal_ch(const char unexpected, const char actual, char *fi
 {
     if(unexpected == actual)
     {
-        register_fail(file, line, "Assert not equal failed: unexpected(%c) and actual(%c) are equal.", unexpected, actual);
+        register_fail(file, line, "Assert not equal failed: '%c' and '%c' are equal.", unexpected, actual);
     }
 }
 
@@ -1030,7 +1030,7 @@ void _assert_are_not_equal_sch(const signed char unexpected, const signed char a
 {
     if(unexpected == actual)
     {
-        register_fail(file, line, "Assert not equal failed: unexpected(%c) and actual(%c) are equal.", unexpected, actual);
+        register_fail(file, line, "Assert not equal failed: '%c' and '%c' are equal.", unexpected, actual);
     }
 }
 
@@ -1038,7 +1038,7 @@ void _assert_are_not_equal_uch(const unsigned char unexpected, const unsigned ch
 {
     if(unexpected == actual)
     {
-        register_fail(file, line, "Assert not equal failed: unexpected(%c) and actual(%c) are equal.", unexpected, actual);
+        register_fail(file, line, "Assert not equal failed: '%c' and '%c' are equal.", unexpected, actual);
     }
 }
 
@@ -1046,7 +1046,7 @@ void _assert_are_not_equal_int(const intmax_t unexpected, const intmax_t actual,
 {
     if(unexpected == actual)
     {
-        register_fail(file, line, "Assert not equal failed: unexpected(%ld) and actual(%ld) are equal.", unexpected, actual);
+        register_fail(file, line, "Assert not equal failed: '%ld' and '%ld' are equal.", unexpected, actual);
     }
 }
 
@@ -1054,7 +1054,7 @@ void _assert_are_not_equal_uint(const uintmax_t unexpected, const uintmax_t actu
 {
     if(unexpected == actual)
     {
-        register_fail(file, line, "Assert not equal failed: unexpected(%ld) and actual(%ld) are equal.", unexpected, actual);
+        register_fail(file, line, "Assert not equal failed: '%ld' and '%ld' are equal.", unexpected, actual);
     }
 }
 
@@ -1072,7 +1072,7 @@ void _assert_are_not_equal_dbl(const long double unexpected, const long double a
 {
     if(fabsl(unexpected - actual) <= LDBL_EPSILON)
     {
-        register_fail(file, line, "Assert not equal failed: unexpected(%0.8Lf) and actual(%0.8Lf) are equal.", unexpected, actual);
+        register_fail(file, line, "Assert not equal failed: '%0.8Lf' and '%0.8Lf' are equal.", unexpected, actual);
     }
 }
 
@@ -1081,7 +1081,7 @@ void _assert_are_not_equal_str(const char *unexpected, const char *actual, char 
     if((unexpected == NULL && actual == NULL) ||
        (unexpected != NULL && actual != NULL && strcmp(unexpected, actual) == 0))
     {
-        register_fail(file, line, "Assert not equal failed: unexpected(%s) and actual(%s) are equal.", unexpected, actual);
+        register_fail(file, line, "Assert not equal failed: '%s' and '%s' are equal.", unexpected, actual);
     }
 }
 
@@ -1090,7 +1090,7 @@ void _assert_are_not_equal_wstr(const wchar_t *unexpected, const wchar_t *actual
     if((unexpected == NULL && actual == NULL) ||
        (unexpected != NULL && actual != NULL && wcscmp(unexpected, actual) == 0))
     {
-        register_fail(file, line, "Assert not equal failed: unexpected(%ls) and actual(%ls) are equal.", unexpected, actual);
+        register_fail(file, line, "Assert not equal failed: '%ls' and '%ls' are equal.", unexpected, actual);
     }
 }
 
@@ -1120,7 +1120,7 @@ void _assert_are_not_equal_precision(const long double  unexpected,
 {
     if(fabsl(unexpected - actual) <= epsilon)
     {
-        register_fail(file, line, "Assert not equal failed: unexpected(%0.10Lf) and actual(%0.10Lf) are equal.", unexpected, actual);
+        register_fail(file, line, "Assert not equal failed: '%0.10Lf' and '%0.10Lf' are equal.", unexpected, actual);
     }
 }
 

--- a/eztest/eztest.h
+++ b/eztest/eztest.h
@@ -41,6 +41,9 @@ struct unit_test
 /** Represents the standard error/ fail result value for non-pointer return types. */
 #define RESULT_ERR -1
 
+/** The max amount of bytes to print when printing value without type. */
+#define MAX_PRINTABLE_LEN 16
+
 #define ANSWER_TO_LIFE 4242424242424242
 
 #define _BASE_TEST_NAME "_base_test"
@@ -820,7 +823,7 @@ static void print_bytes(const void *ptr, size_t n)
     const unsigned char *bytes = (const unsigned char *)ptr;
     for (; n > 0; --n, ++bytes)
     {
-        printf("%02X ", *bytes);
+        printf("%x", *bytes);
     }
 }
 
@@ -906,18 +909,19 @@ void _assert_is_nan(const float value, char *file, const int line)
 
 #endif
 
-void _assert_equal_mem(const void *expected, const void *actual, size_t size, char *file, const int line)
+void _assert_equal_mem(const void *expected, const void *actual, const size_t size, char *file, const int line)
 {
     if((expected == NULL && actual != NULL) ||
        (expected != NULL && actual == NULL) ||
        (expected != NULL && memcmp(expected, actual, size) != 0))
     {
         result = fail;
-        printf("[%s : %s]%s Assert are equal failed: expected ",
-               current->test_suite, current->test_name, color(COLOR_YELLOW));
-        print_bytes(expected, size);
-        printf("but got ");
-        print_bytes(actual, size);
+        printf("[%s : %s]%s Assert are equal failed: expected '0x",
+                current->test_suite, current->test_name, color(COLOR_YELLOW));
+        print_bytes(expected, (size > MAX_PRINTABLE_LEN ? MAX_PRINTABLE_LEN : size));
+        printf("%s', but got '0x", (size > MAX_PRINTABLE_LEN ? "..." : ""));
+        print_bytes(actual, (size > MAX_PRINTABLE_LEN ? MAX_PRINTABLE_LEN : size));
+        printf((size > MAX_PRINTABLE_LEN ? "...'." : "'."));
         print_file_marker(file, line);
     }
 }

--- a/eztest/eztest.h
+++ b/eztest/eztest.h
@@ -1108,7 +1108,7 @@ void _assert_are_equal_precision(const long double  expected,
 {
     if(fabsl(expected - actual) > epsilon)
     {
-        register_fail(file, line, "Assert are equal failed: expected '%0.10Lf', but got '%0.10Lf'.", expected, actual);
+        register_fail(file, line, "Assert are equal failed: expected '%0.8Lf', but got '%0.8Lf'.", expected, actual);
     }
 }
 
@@ -1120,7 +1120,7 @@ void _assert_are_not_equal_precision(const long double  unexpected,
 {
     if(fabsl(unexpected - actual) <= epsilon)
     {
-        register_fail(file, line, "Assert not equal failed: '%0.10Lf' and '%0.10Lf' are equal.", unexpected, actual);
+        register_fail(file, line, "Assert not equal failed: '%0.8Lf' and '%0.8Lf' are equal.", unexpected, actual);
     }
 }
 


### PR DESCRIPTION
# Description

- The output format was previously not consistent. Values are now printed only using the format: 'value'. 
- A limit has been set on the amount of bytes to print when type is unknown (output from assert_equal_mem).

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
