### PR TITLE
Fixed memory bug

### DIFF
--- a/eztest/eztest.h
+++ b/eztest/eztest.h
@@ -1572,6 +1572,10 @@ static bool should_skip(const struct unit_test *test)
         return false;
     }
     char *skip_list_cp = malloc((strlen(skip_list) + 1) * sizeof(char));
+    if(skip_list_cp == NULL)
+    {
+        return false;
+    }
     strcpy(skip_list_cp, skip_list);
  
     char *token;
@@ -1580,6 +1584,7 @@ static bool should_skip(const struct unit_test *test)
     {
         if(strcmp(token, test->test_suite) == 0)
         {
+            free(skip_list_cp);
             return true;
         }
         token = strtok(NULL, separator);


### PR DESCRIPTION
# Description
After allocating memory for the skip list the was not an error check. In the event of finding a matching suite to skip the memory was not freed. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
